### PR TITLE
Update Page Model for Rails 5

### DIFF
--- a/app/models/documentation/page.rb
+++ b/app/models/documentation/page.rb
@@ -8,7 +8,7 @@ module Documentation
     default_scope -> { order(:position) }
     scope :roots, -> { where(:parent_id => nil) }
 
-    belongs_to :parent, :class_name => 'Documentation::Page', :foreign_key => 'parent_id'
+    belongs_to :parent, :class_name => 'Documentation::Page', :foreign_key => 'parent_id', optional: true
 
     before_validation do
       if self.position.blank?


### PR DESCRIPTION
belongs_to is now explicitly required in the Rails 5 beta. In this situation, an optional parent_id is needed to set a root page with no parent.

Not sure if you want to pull in changes for the beta version of Rails 5 - but I figured I would send it your way and let you decide.

Cheers.