### PR TITLE
Make #controller available as a method

### DIFF
--- a/lib/documentation/authorizer.rb
+++ b/lib/documentation/authorizer.rb
@@ -1,5 +1,6 @@
 module Documentation
   class Authorizer
+    attr_reader :controller
 
     def initialize(controller)
       @controller = controller


### PR DESCRIPTION
Documentation::Authorizer the controller was set to `@controller` but there was no reader or accessor method defined which meant the examples didn't work