### PR TITLE
Noting Sunspot search backend

### DIFF
--- a/doc/developers-guide/search-backends.md
+++ b/doc/developers-guide/search-backends.md
@@ -2,7 +2,7 @@ By default, Documentation uses a very very simple search which uses a LIKE query
 
 ## Elasticsearch
 
-The recommended method of indexing & searching data is to use Elasticsearch. A module is provided for this [on GitHub](https://github.com/adamcooke/documentation-elasticsearch) and can be installed by following the instructions on the repo's README page.
+The recommended method of indexing & searching data is to use Elasticsearch. A module is provided for this [on GitHub](https://github.com/adamcooke/documentation-elasticsearch) and can be installed by following the instructions on the repo's README page.  There is also a Sunspot backend for working with Solr instances [on GitHub](https://github.com/jamesprior/documentation-sunspot)
 
 ## Creating your own search backend
 


### PR DESCRIPTION
I wrote a Sunspot search backend for the documentation engine and it seemed like the documentation was the best place to note its availability.